### PR TITLE
Fix thanks page top spacing and remove Helm from about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -30,7 +30,7 @@ const experience: TimelineEntry[] = [
         dateRange: 'Jan 2026 - Present',
         bullets: [
           'Led backend development for multiple core features on a new initiative, helping shape the architecture and take systems into production.',
-          'Built a production deployment pipeline with GitHub Actions, Terraform, and Kubernetes (Helm), with Slack and Linear integrations to give non-technical stakeholders better visibility and reduce engineering overhead.',
+          'Built a production deployment pipeline with GitHub Actions, Terraform, and Kubernetes, with Slack and Linear integrations to give non-technical stakeholders better visibility and reduce engineering overhead.',
         ],
       },
       {

--- a/src/app/thanks/page.tsx
+++ b/src/app/thanks/page.tsx
@@ -35,7 +35,7 @@ export default function ThanksPage() {
       <Header />
 
       {/* Content */}
-      <main className="relative flex-1 flex flex-col items-center px-6 md:px-12 pb-12">
+      <main className="relative flex-1 flex flex-col items-center px-6 md:px-12 pt-8 md:pt-12 pb-12">
         <h1
           className="text-4xl md:text-5xl font-bold tracking-tight text-[var(--color-foreground)] mb-4 animate-fade-up"
           style={{ fontFamily: "var(--font-heading)" }}


### PR DESCRIPTION
Add pt-8 md:pt-12 to thanks page main element to match spacing
on about and projects pages. Remove "(Helm)" from deployment
pipeline description.

https://claude.ai/code/session_01NpAiVWn3pfwn1aNpjki88U