### PR TITLE
Only play home screen entrance animation on first load per session

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,6 +101,21 @@ body {
   opacity: 0;
 }
 
+/* Skip entrance animations on return visits within the same session */
+.home-visited .animate-fade-up,
+.home-visited .animate-fade-in {
+  animation: none !important;
+}
+
+.home-visited .animate-fade-up,
+.home-visited .animate-fade-in,
+.home-visited .animate-delay-100,
+.home-visited .animate-delay-200,
+.home-visited .animate-delay-300,
+.home-visited .animate-delay-400 {
+  opacity: 1 !important;
+}
+
 /* Gradient text */
 .gradient-text {
   background: linear-gradient(

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="antialiased">{children}</body>
+      <body className="antialiased">
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if(sessionStorage.getItem('home-visited')){document.documentElement.classList.add('home-visited')}`,
+          }}
+        />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const navLinks = [
   { href: "/about", label: "ABOUT ME" },
@@ -11,6 +11,10 @@ const navLinks = [
 
 export default function Home() {
   const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    sessionStorage.setItem("home-visited", "true");
+  }, []);
 
   return (
     <div className="h-dvh flex flex-col relative overflow-hidden">


### PR DESCRIPTION
Uses sessionStorage + an inline pre-hydration script to skip
the fade-up/fade-in animations on return visits within the same
browsing session.

https://claude.ai/code/session_01UAWoQCgfngUZHbnbjSERQi